### PR TITLE
Removed Post-Build action

### DIFF
--- a/OpenImageIO/OpenImageIO.vcxproj
+++ b/OpenImageIO/OpenImageIO.vcxproj
@@ -91,7 +91,8 @@
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Lib>
     <PostBuildEvent>
-      <Command>Copy "$(TargetPath)" "$(ProjectDir)..\csycles_tester\bin\$(Configuration)"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/csycles/csycles.csproj
+++ b/csycles/csycles.csproj
@@ -127,7 +127,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>Copy /Y "$(TargetPath)" "$(ProjectDir)..\csycles_tester\bin\$(ConfigurationName)"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>

--- a/pthreads/pthreads.vcxproj
+++ b/pthreads/pthreads.vcxproj
@@ -57,7 +57,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>Copy "$(TargetPath)" "$(ProjectDir)..\csycles_tester\bin\$(Configuration)"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">


### PR DESCRIPTION
This should be done in the program's post build events, not in the library that's being build.
